### PR TITLE
fix: replace blocking Thread.sleep with reactive delays in Polaris cl…

### DIFF
--- a/dcb/src/main/java/org/olf/dcb/core/interaction/polaris/PolarisLmsClient.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/polaris/PolarisLmsClient.java
@@ -328,16 +328,9 @@ public class PolarisLmsClient implements MarcIngestSource<PolarisLmsClient.BibsP
 
 	private Mono<Integer> getILLRequestId(String patronLocalId, String title) {
 
-		// TEMPORARY WORKAROUND - Wait for polaris to process the hold and make it
-		// visible
-		synchronized (this) {
-			try {
-				Thread.sleep(2000);
-			} catch (Exception e) {
-			}
-		}
-
-		return ApplicationServices.getIllRequest(patronLocalId)
+		// Wait for Polaris to process the hold using reactive delay (non-blocking)
+		return Mono.delay(Duration.ofSeconds(2))
+			.then(ApplicationServices.getIllRequest(patronLocalId))
 			.doOnNext(entries -> log.debug("Got Polaris Holds: {}", entries))
 			.flatMapMany(Flux::fromIterable)
 			.filter(illRequest -> Objects.equals(illRequest.getTitle(), title))
@@ -355,16 +348,9 @@ public class PolarisLmsClient implements MarcIngestSource<PolarisLmsClient.BibsP
 	public Mono<LocalRequest> getLocalHoldRequestIdv2(String patronId, String title, String note, String activationDate) {
 		log.debug("getLocalHoldRequestIdv2({}, {}, {}, {})", patronId, title, note, activationDate);
 
-		// TEMPORARY WORKAROUND - Wait for polaris to process the hold and make it
-		// visible
-		synchronized (this) {
-			try {
-				Thread.sleep(2000);
-			} catch (Exception e) {
-			}
-		}
-
-		return ApplicationServices.listPatronLocalHolds(patronId)
+		// Wait for Polaris to process the hold using reactive delay (non-blocking)
+		return Mono.delay(Duration.ofSeconds(2))
+			.then(ApplicationServices.listPatronLocalHolds(patronId))
 			.doOnNext(entries -> log.debug("Got Polaris Holds: {}", entries))
 			.flatMapMany(Flux::fromIterable)
 			.filter(holds -> shouldIncludeHold(holds, title, note, activationDate))


### PR DESCRIPTION
## Description
Fixes DCB-1277: Connection timeout issues caused by blocking reactive threads in Polaris client

## Problem
The PolarisLmsClient was using blocking `Thread.sleep(2000)` wrapped in `synchronized(this)` blocks in two methods:
- `getILLRequestId()` 
- `getLocalHoldRequestIdv2()`

This caused:
- Blocked reactive threads leading to HTTP connection timeouts (>30 seconds)
- "Connection closed" errors in logs
- Scalability bottlenecks affecting Polaris library requests

## Solution
Replaced blocking delays with reactive delays:
- Changed `Thread.sleep(2000)` to `Mono.delay(Duration.ofSeconds(2))`
- Removed `synchronized` blocks
- Maintains the 2-second delay functionality while allowing reactive streams to process other requests

## Changes
- `dcb/src/main/java/org/olf/dcb/core/interaction/polaris/PolarisLmsClient.java`
  - Line 329-333: Replace blocking delay in `getILLRequestId()`
  - Line 348-353: Replace blocking delay in `getLocalHoldRequestIdv2()`

## Testing
- [x] Code compiles without errors
- [x] Duration import already present in PolarisLmsClient
- [ ] Manual testing of Polaris hold requests recommended
- [ ] Verify connection timeouts no longer occur

## Risk Assessment
**Risk Level:** LOW
- No database changes
- No API signature changes  
- No configuration changes required
- Preserves existing 2-second delay behavior
- Easy rollback (single commit revert)

**Technical Risk:**
- `Mono.delay()` is well-established reactive pattern in the codebase
- Duration import already present in PolarisLmsClient
- No breaking changes to downstream consumers

**Impact:** HIGH
- **Performance**: Eliminates reactive thread blocking that caused 30+ second timeouts
- **Scalability**: Removes synchronization bottleneck affecting all Polaris requests
- **Reliability**: Prevents "Connection closed" errors seen in production
- **Scope**: Fixes issues affecting all Polaris libraries in the consortium

**Rollback Plan:**
Single commit revert restores original `Thread.sleep()` implementation if issues arise.

Refs: DCB-1277