### PR TITLE
fix: preserve cached availability status instead of showing UNKNOWN

### DIFF
--- a/dcb/src/main/java/org/olf/dcb/item/availability/LiveAvailabilityService.java
+++ b/dcb/src/main/java/org/olf/dcb/item/availability/LiveAvailabilityService.java
@@ -302,18 +302,10 @@ public class LiveAvailabilityService {
 	private static final ItemStatus STATUS_UNKNOWN = new ItemStatus(ItemStatusCode.UNKNOWN);
 	
 	private AvailabilityReport modifyCachedRecord(AvailabilityReport ar) {
-		// Build new item lists and set the status to unknown.
-		List<Item> newItems = new ArrayList<>();
-		ar.getItems().stream()
-			.map( Item::toBuilder )
-			.map( itemBuilder -> itemBuilder
-				.status(STATUS_UNKNOWN)
-				.build())
-			.forEach( newItems::add );
-		
-		return ar.toBuilder()
-			.items(newItems)
-			.build();
+		// Return cached data with original statuses preserved
+		// Cached status is better than showing "unknown" to users
+		log.debug("Returning cached availability data with preserved statuses");
+		return ar;
 	}
 	
 	private static AvailabilityReport getNoCachedValueErrorReport(String message) {


### PR DESCRIPTION
## Description
Fixes DCB-1277: UX issue where cached availability fallback shows "UNKNOWN" status

## Problem
The cache fallback in LiveAvailabilityService was destroying status information by overwriting all cached statuses to UNKNOWN in the `modifyCachedRecord()` method.

This caused:
- Users seeing "UNKNOWN" status instead of actual cached availability
- Poor user experience during temporary system issues
- Loss of useful cached data that was only seconds/minutes old

## Solution
Preserve cached availability status:
- Modified `modifyCachedRecord()` to return cached data as-is
- Cached status (even if 1 minute old) is far better than showing "UNKNOWN" to users
- System already handles conflicts if items become unavailable

## Changes
- `dcb/src/main/java/org/olf/dcb/item/availability/LiveAvailabilityService.java`
  - Line 304-309: Preserve cached status instead of overwriting to UNKNOWN
  - Added debug logging when returning cached data

## Testing
- [x] Code compiles without errors
- [ ] Manual testing of cache fallback scenarios recommended
- [ ] Verify cached status displays correctly when live queries fail

## Risk Assessment
**Risk Level:** LOW  
- No database changes
- No API signature changes
- No configuration changes required
- Simplifies code by removing status mutation logic
- Easy rollback (single commit revert)

**Technical Risk:**
- Change only affects cache fallback path (error scenarios)
- Does not modify primary availability query flow
- System already handles conflicts if cached data is stale

**Impact:** HIGH
- **User Experience**: Users see actual cached status instead of "UNKNOWN" for all items
- **Data Quality**: Cached status (even if 1 minute old) provides better information than "UNKNOWN"
- **Transparency**: Users get more accurate availability information during system issues
- **Scope**: Improves UX for all library patrons when live availability queries fail

**Rollback Plan:**
Single commit revert restores original UNKNOWN status behavior if cached data proves problematic.

Refs: DCB-1277