### PR TITLE
DCB-2203: Add DTOs for Folio Inventory Items and Instances

### DIFF
--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClient.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClient.java
@@ -1397,13 +1397,13 @@ public class ConsortialFolioHostLmsClient implements HostLmsClient {
 			.uri(uriBuilder -> uriBuilder.queryParam("query", query));
 
 		return makeRequest(request, Argument.of(InventoryItemCollection.class))
-			.flatMap(itemsCollection -> {
+			.<HostLmsItem>flatMap(itemsCollection -> {
 				if (isEmpty(itemsCollection.getItems())) {
 					log.warn("No item found in FOLIO for barcode: {}", barcode);
 					return Mono.empty();
 				}
 
-				var item = itemsCollection.getItems().getFirst();
+				var item = itemsCollection.getItems().iterator().next();
 				if (item.getBarcode() == null) {
 					item.setBarcode(barcode);
 				}
@@ -1450,12 +1450,12 @@ public class ConsortialFolioHostLmsClient implements HostLmsClient {
 			.uri(uriBuilder -> uriBuilder.queryParam("query", query));
 
 		return makeRequest(request, Argument.of(InventoryInstanceCollection.class))
-			.flatMap(instanceCollection -> {
+			.<String>flatMap(instanceCollection -> {
 				if (isEmpty(instanceCollection.getInstances())) {
 					log.warn("No instance found in FOLIO for holdingsRecordId: {}", holdingsRecordId);
 					return Mono.empty();
 				}
-				var instance = instanceCollection.getInstances().getFirst();
+				var instance = instanceCollection.getInstances().iterator().next();
 				return Mono.just(instance.getId());
 			})
 			.onErrorResume(e -> {

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClient.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClient.java
@@ -1396,39 +1396,18 @@ public class ConsortialFolioHostLmsClient implements HostLmsClient {
 		final var request = authorisedRequest(GET, PATH_INVENTORY_ITEMS)
 			.uri(uriBuilder -> uriBuilder.queryParam("query", query));
 
-		return makeRequest(request, Argument.of(io.micronaut.json.tree.JsonNode.class))
-			.flatMap(node -> {
-				var items = node.get("items");
-
-				if (items == null || items.size() == 0) {
+		return makeRequest(request, Argument.of(InventoryItemCollection.class))
+			.flatMap(itemsCollection -> {
+				if (isEmpty(itemsCollection.getItems())) {
 					log.warn("No item found in FOLIO for barcode: {}", barcode);
 					return Mono.empty();
 				}
 
-				var item = items.values().iterator().next();
-				var id = item.get("id").getStringValue();
-				var fetchedBarcode = item.get("barcode") != null ? item.get("barcode").getStringValue() : barcode;
-
-				var statusNode = item.get("status");
-				var rawStatus = statusNode != null ? statusNode.get("name").getStringValue() : "Unknown";
-
-				var holdingsRecordId = item.get("holdingsRecordId") != null ? item.get("holdingsRecordId").getStringValue() : null;
-				log.info("Item is {}", item);
-
-				// If we already have instance ID (unlikely) we don't have to go searching
-				var directInstanceIdNode = item.get("instanceId");
-				if (directInstanceIdNode != null && !directInstanceIdNode.isNull()) {
-					return Mono.just(buildHostLmsItem(id, fetchedBarcode, rawStatus, directInstanceIdNode.getStringValue()));
+				var item = itemsCollection.getItems().getFirst();
+				if (item.getBarcode() == null) {
+					item.setBarcode(barcode);
 				}
-
-				if (holdingsRecordId == null) {
-					log.warn("No holdingsRecordId found for item barcode: {} - cannot resolve Bib ID", barcode);
-					return Mono.just(buildHostLmsItem(id, fetchedBarcode, rawStatus, null));
-				}
-
-				return fetchInstanceIdFromInventory(holdingsRecordId)
-					.map(fetchedInstanceId -> buildHostLmsItem(id, fetchedBarcode, rawStatus, fetchedInstanceId))
-					.defaultIfEmpty(buildHostLmsItem(id, fetchedBarcode, rawStatus, null));
+				return buildHostLmsItem(item);
 			})
 			.doOnError(e -> log.error("Failed to fetch item by barcode {} from FOLIO: {}", barcode, e.getMessage()));
 	}
@@ -1445,6 +1424,24 @@ public class ConsortialFolioHostLmsClient implements HostLmsClient {
 		};
 	}
 
+	private Mono<HostLmsItem> buildHostLmsItem(InventoryItem item) {
+		log.info("Item is {}", item);
+
+		var id = item.getId();
+		var barcode = item.getBarcode();
+		var rawStatus = item.getStatus() != null ? item.getStatus().getName() : "Unknown";
+		var holdingsRecordId = item.getHoldingsRecordId();
+
+		if (holdingsRecordId == null) {
+			log.warn("No holdingsRecordId found for item barcode: {} - cannot resolve Bib ID", barcode);
+			return Mono.just(buildHostLmsItem(id, barcode, rawStatus, null));
+		}
+
+		return fetchInstanceIdFromInventory(holdingsRecordId)
+			.map(fetchedInstanceId -> buildHostLmsItem(id, barcode, rawStatus, fetchedInstanceId))
+			.defaultIfEmpty(buildHostLmsItem(id, barcode, rawStatus, null));
+	}
+
 	private Mono<String> fetchInstanceIdFromInventory(String holdingsRecordId) {
 		log.debug("Fetching instance record via holdingsRecordId {} to resolve instanceId", holdingsRecordId);
 
@@ -1452,17 +1449,14 @@ public class ConsortialFolioHostLmsClient implements HostLmsClient {
 		final var request = authorisedRequest(GET, PATH_INVENTORY_INSTANCES)
 			.uri(uriBuilder -> uriBuilder.queryParam("query", query));
 
-		return makeRequest(request, Argument.of(io.micronaut.json.tree.JsonNode.class))
-			.flatMap(node -> {
-				var instances = node.get("instances");
-				if (instances != null && instances.size() > 0) {
-					var instance = instances.values().iterator().next();
-					var idNode = instance.get("id");
-					if (idNode != null && !idNode.isNull()) {
-						return Mono.just(idNode.getStringValue());
-					}
+		return makeRequest(request, Argument.of(InventoryInstanceCollection.class))
+			.flatMap(instanceCollection -> {
+				if (isEmpty(instanceCollection.getInstances())) {
+					log.warn("No instance found in FOLIO for holdingsRecordId: {}", holdingsRecordId);
+					return Mono.empty();
 				}
-				return Mono.empty();
+				var instance = instanceCollection.getInstances().getFirst();
+				return Mono.just(instance.getId());
 			})
 			.onErrorResume(e -> {
 				log.error("Failed to fetch instance for holding {} for instanceId resolution: {}", holdingsRecordId, e.getMessage());

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryInstance.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryInstance.java
@@ -1,0 +1,13 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Builder;
+import lombok.Data;
+
+@Serdeable
+@Builder
+@Data
+public class InventoryInstance {
+	@Nullable private String id;
+}

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryInstanceCollection.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryInstanceCollection.java
@@ -1,0 +1,14 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Serdeable
+@Builder
+@Data
+public class InventoryInstanceCollection {
+	@Nullable private List<InventoryInstance> instances;
+}

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItem.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItem.java
@@ -1,0 +1,16 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Builder;
+import lombok.Data;
+
+@Serdeable
+@Builder
+@Data
+public class InventoryItem {
+	@Nullable private String id;
+	@Nullable private String barcode;
+	@Nullable private String holdingsRecordId;
+	@Nullable private InventoryItemStatus status;
+}

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItemCollection.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItemCollection.java
@@ -1,0 +1,14 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Serdeable
+@Builder
+@Data
+public class InventoryItemCollection {
+	@Nullable List<InventoryItem> items;
+}

--- a/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItemStatus.java
+++ b/dcb/src/main/java/org/olf/dcb/core/interaction/folio/InventoryItemStatus.java
@@ -1,0 +1,13 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import lombok.Builder;
+import lombok.Value;
+
+@Serdeable
+@Value
+@Builder
+public class InventoryItemStatus {
+	@Nullable String name;
+}

--- a/dcb/src/test/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClientGetItemsByBarcodeTests.java
+++ b/dcb/src/test/java/org/olf/dcb/core/interaction/folio/ConsortialFolioHostLmsClientGetItemsByBarcodeTests.java
@@ -1,0 +1,311 @@
+package org.olf.dcb.core.interaction.folio;
+
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockserver.client.MockServerClient;
+import org.olf.dcb.core.interaction.HostLmsClient;
+import org.olf.dcb.core.interaction.HostLmsItem;
+import org.olf.dcb.test.HostLmsFixture;
+import org.olf.dcb.test.TestResourceLoaderProvider;
+import services.k_int.test.mockserver.MockServerMicronautTest;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.olf.dcb.test.PublisherUtils.singleValueFrom;
+import static org.olf.dcb.test.matchers.interaction.HostLmsItemMatchers.hasBarcode;
+import static org.olf.dcb.test.matchers.interaction.HostLmsItemMatchers.hasBibId;
+import static org.olf.dcb.test.matchers.interaction.HostLmsItemMatchers.hasLocalId;
+import static org.olf.dcb.test.matchers.interaction.HostLmsItemMatchers.hasRawStatus;
+import static org.olf.dcb.test.matchers.interaction.HostLmsItemMatchers.hasStatus;
+
+@MockServerMicronautTest
+class ConsortialFolioHostLmsClientGetItemsByBarcodeTests {
+	private static final String CATALOGUING_HOST_LMS_CODE = "folio-cataloguing-host-lms";
+
+	@Inject
+	private TestResourceLoaderProvider testResourceLoaderProvider;
+
+	@Inject
+	private HostLmsFixture hostLmsFixture;
+
+	private MockFolioFixture mockFolioFixture;
+	private HostLmsClient client;
+
+	@BeforeEach
+	void beforeEach(MockServerClient mockServerClient) {
+		final var API_KEY = "eyJzIjoic2FsdCIsInQiOiJ0ZW5hbnQiLCJ1IjoidXNlciJ9";
+
+		hostLmsFixture.deleteAll();
+
+		hostLmsFixture.createFolioHostLms(CATALOGUING_HOST_LMS_CODE, "https://fake-cataloguing-folio",
+			API_KEY, "", "");
+
+		mockServerClient.reset();
+		mockFolioFixture = new MockFolioFixture(mockServerClient, testResourceLoaderProvider, "fake-cataloguing-folio", API_KEY);
+
+		client = hostLmsFixture.createClient(CATALOGUING_HOST_LMS_CODE);
+	}
+
+	@Test
+	void shouldFindAvailableItemByBarcode() {
+		// Arrange
+		final var barcode = "2222222";
+		final var expectedItemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+		final var expectedHoldingsRecordId = "16f40c4e-235d-4912-a683-2ad919cc8b07";
+		final var expectedInstanceId = "7fbd5d84-62d1-44c6-9c45-6cb173998c26";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, "query-items-response.json");
+		mockFolioFixture.mockQueryInstancesByHoldingsRecordId(expectedHoldingsRecordId, "query-instances-response.json");
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(expectedItemId),
+			hasBarcode(barcode),
+			hasStatus("AVAILABLE"),
+			hasRawStatus("Available"),
+			hasBibId(expectedInstanceId)
+		));
+	}
+
+	@Test
+	void shouldReturnNullWhenNoItemFound() {
+		// Arrange
+		final var barcode = "nonexistent";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder().items(List.of()).build())));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, nullValue());
+	}
+
+	@Test
+	void shouldReturnItemWithoutBibIdWhenHoldingsRecordIdIsNull() {
+		// Arrange
+		final var barcode = "3333333";
+		final var itemId = "a1234567-89ab-cdef-0123-456789abcdef";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(barcode)
+					.holdingsRecordId(null)
+					.status(InventoryItemStatus.builder().name("Available").build())
+					.build()))
+				.build())));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(barcode),
+			hasStatus("AVAILABLE"),
+			hasRawStatus("Available"),
+			hasBibId(null)
+		));
+	}
+
+	@Test
+	void shouldSetBarcodeFromInputWhenItemHasNullBarcode() {
+		// Arrange
+		final var inputBarcode = "123";
+		final var itemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+
+		mockFolioFixture.mockQueryItemsByBarcode(inputBarcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(null) // item has no barcode in response
+					.holdingsRecordId(null)
+					.status(InventoryItemStatus.builder().name("Available").build())
+					.build()))
+				.build())));
+
+		// Act
+		final var item = getLmsItem(inputBarcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(inputBarcode), // barcode should be set from input
+			hasStatus("AVAILABLE")
+		));
+	}
+
+	@Test
+	void shouldMapNullStatusToUnknown() {
+		// Arrange
+		final var barcode = "123";
+		final var itemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(barcode)
+					.holdingsRecordId(null)
+					.status(null) // null status
+					.build()))
+				.build())));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(barcode),
+			hasStatus("Unknown"),
+			hasRawStatus("Unknown")
+		));
+	}
+
+	@Test
+	void shouldReturnItemWithoutBibIdWhenInstanceNotFoundForHoldingsRecordId() {
+		// Arrange
+		final var barcode = "123";
+		final var itemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+		final var holdingsRecordId = "16f40c4e-235d-4912-a683-2ad919cc8b07";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(barcode)
+					.holdingsRecordId(holdingsRecordId)
+					.status(InventoryItemStatus.builder().name("Available").build())
+					.build()))
+				.build())));
+
+		// Mock empty instance response for holdingsRecordId
+		mockFolioFixture.mockQueryInstancesByHoldingsRecordId(holdingsRecordId, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryInstanceCollection.builder()
+				.instances(List.of())
+				.build())));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(barcode),
+			hasStatus("AVAILABLE"),
+			hasBibId(null) // bibId should be null when instance not found
+		));
+	}
+
+	@Test
+	void shouldReturnItemWithoutBibIdWhenInstanceFetchFails() {
+		// Arrange
+		final var barcode = "123";
+		final var itemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+		final var holdingsRecordId = "16f40c4e-235d-4912-a683-2ad919cc8b07";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(barcode)
+					.holdingsRecordId(holdingsRecordId)
+					.status(InventoryItemStatus.builder().name("Available").build())
+					.build()))
+				.build())));
+
+		// Mock error response for instance fetch
+		mockFolioFixture.mockQueryInstancesByHoldingsRecordId(holdingsRecordId, response()
+			.withStatusCode(500)
+			.withBody("Internal Server Error"));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(barcode),
+			hasStatus("AVAILABLE"),
+			hasBibId(null) // bibId should be null when instance fetch fails
+		));
+	}
+
+	@ParameterizedTest(name = "should map \"{0}\" status to \"{1}\"")
+	@MethodSource("statusMappingProvider")
+	void shouldMapStatusCorrectly(String rawStatus, String expectedMappedStatus) {
+		// Arrange
+		final var barcode = "123";
+		final var itemId = "9a326225-6530-41cc-9399-a61987bfab3c";
+
+		mockFolioFixture.mockQueryItemsByBarcode(barcode, response()
+			.withStatusCode(200)
+			.withBody(json(InventoryItemCollection.builder()
+				.items(List.of(InventoryItem.builder()
+					.id(itemId)
+					.barcode(barcode)
+					.holdingsRecordId(null)
+					.status(InventoryItemStatus.builder().name(rawStatus).build())
+					.build()))
+				.build())));
+
+		// Act
+		final var item = getLmsItem(barcode);
+
+		// Assert
+		assertThat(item, allOf(
+			notNullValue(),
+			hasLocalId(itemId),
+			hasBarcode(barcode),
+			hasStatus(expectedMappedStatus),
+			hasRawStatus(rawStatus)
+		));
+	}
+
+	private static Stream<Arguments> statusMappingProvider() {
+		return Stream.of(
+			Arguments.of("Checked out", "LOANED"),
+			Arguments.of("In transit", "TRANSIT"),
+			Arguments.of("Awaiting pickup", "HOLDSHELF"),
+			Arguments.of("Missing", "MISSING"),
+			Arguments.of("Declared lost", "MISSING"),
+			Arguments.of("Some unknown status", "Some unknown status")
+		);
+	}
+
+	@Nullable
+	private HostLmsItem getLmsItem(String barcode) {
+		return singleValueFrom(client.getItemByBarcode(barcode));
+	}
+}

--- a/dcb/src/test/java/org/olf/dcb/core/interaction/folio/MockFolioFixture.java
+++ b/dcb/src/test/java/org/olf/dcb/core/interaction/folio/MockFolioFixture.java
@@ -16,6 +16,7 @@ import org.olf.dcb.test.MockServerCommonRequests;
 import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Value;
+import org.olf.dcb.test.TestResourceLoaderProvider;
 
 public class MockFolioFixture {
 	private final MockServer mockServer;
@@ -24,6 +25,13 @@ public class MockFolioFixture {
 	public MockFolioFixture(MockServerClient mockServerClient, String host, String apiKey) {
 		this.commonRequests = new MockServerCommonRequests(host, apiKey);
 		this.mockServer = new MockServer(mockServerClient, commonRequests);
+	}
+
+	public MockFolioFixture(MockServerClient mockServerClient, TestResourceLoaderProvider testResourceLoaderProvider,
+													String host, String apiKey) {
+		this.commonRequests = new MockServerCommonRequests(host, apiKey);
+		this.mockServer = new MockServer(mockServerClient, commonRequests,
+			testResourceLoaderProvider.forBasePath("classpath:mock-responses/folio/"));
 	}
 
 	void mockHoldingsByInstanceId(String instanceId, Holding... holdings) {
@@ -130,6 +138,25 @@ public class MockFolioFixture {
 
 	private static String renewTransactionPath(String transactionId) {
 		return "/dcbService/transactions/%s/renew".formatted(transactionId);
+	}
+
+	public void mockQueryItemsByBarcode(String barcode, String jsonResourcePath) {
+		mockServer.mockGet("/inventory/items", "query", "barcode==\"" + barcode + "\"",
+			okJson(mockServer.getResource(jsonResourcePath)));
+	}
+
+	public void mockQueryItemsByBarcode(String barcode, HttpResponse response) {
+		mockServer.mockGet("/inventory/items", "query", "barcode==\"" + barcode + "\"", response);
+	}
+
+	public void mockQueryInstancesByHoldingsRecordId(String holdingsRecordId, String jsonResourcePath) {
+		mockServer.mockGet("/inventory/instances", "query", "holdingsRecords.id==\"" + holdingsRecordId + "\"",
+			okJson(mockServer.getResource(jsonResourcePath)));
+	}
+
+	public void mockQueryInstancesByHoldingsRecordId(String holdingsRecordId, HttpResponse response) {
+		mockServer.mockGet("/inventory/instances", "query", "holdingsRecords.id==\"" + holdingsRecordId + "\"",
+			response);
 	}
 
 	@Serdeable

--- a/dcb/src/test/java/org/olf/dcb/test/MockServer.java
+++ b/dcb/src/test/java/org/olf/dcb/test/MockServer.java
@@ -137,7 +137,7 @@ public class MockServer {
 		verifyNever(commonRequests.put(path));
 	}
 
-	private Object getResource(String jsonResourcePath) {
+	public Object getResource(String jsonResourcePath) {
 		return resourceLoader.getResource(jsonResourcePath);
 	}
 }

--- a/dcb/src/test/java/org/olf/dcb/test/matchers/interaction/HostLmsItemMatchers.java
+++ b/dcb/src/test/java/org/olf/dcb/test/matchers/interaction/HostLmsItemMatchers.java
@@ -7,8 +7,6 @@ import static services.k_int.utils.StringUtils.convertIntegerToString;
 import org.hamcrest.Matcher;
 import org.olf.dcb.core.interaction.HostLmsItem;
 
-import services.k_int.utils.StringUtils;
-
 public class HostLmsItemMatchers {
 	public static Matcher<HostLmsItem> hasStatus(String expectedStatus) {
 		return hasProperty("status", is(expectedStatus));
@@ -32,5 +30,9 @@ public class HostLmsItemMatchers {
 
 	public static Matcher<HostLmsItem> hasRenewalCount(Integer count) {
 		return hasProperty("renewalCount", is(count));
+	}
+
+	public static Matcher<HostLmsItem> hasBibId(String expectedBibId) {
+		return hasProperty("bibId", is(expectedBibId));
 	}
 }

--- a/dcb/src/test/resources/mock-responses/folio/query-instances-response.json
+++ b/dcb/src/test/resources/mock-responses/folio/query-instances-response.json
@@ -1,0 +1,21 @@
+{
+  "instances": [
+    {
+      "id": "7fbd5d84-62d1-44c6-9c45-6cb173998c26",
+      "title": "Water resources of East Feliciana Parish, Louisiana",
+      "source": "FOLIO",
+      "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+      "_version": "1",
+      "hrid": "inst000000000001",
+      "discoverySuppress": false,
+      "metadata": {
+        "createdDate": "2021-10-05T10:23:43.452+00:00",
+        "createdByUserId": "e2f5ebb7-9285-58f8-bc1e-608ac2080861",
+        "updatedDate": "2021-10-06T13:28:29.832+00:00",
+        "updatedByUserId": "e2f5ebb7-9285-58f8-bc1e-608ac2080861"
+      }
+    }
+  ],
+  "totalRecords": 1
+}
+

--- a/dcb/src/test/resources/mock-responses/folio/query-items-response.json
+++ b/dcb/src/test/resources/mock-responses/folio/query-items-response.json
@@ -1,0 +1,69 @@
+{
+  "items": [
+    {
+      "id": "9a326225-6530-41cc-9399-a61987bfab3c",
+      "_version": "4",
+      "status": {
+        "name": "Available",
+        "date": "2021-10-05T10:23:43.453+00:00"
+      },
+      "title": "Water resources of East Feliciana Parish, Louisiana",
+      "hrid": "it00000000001",
+      "contributorNames": [
+        {
+          "name": "White, Vincent E"
+        }
+      ],
+      "formerIds": [],
+      "discoverySuppress": false,
+      "holdingsRecordId": "16f40c4e-235d-4912-a683-2ad919cc8b07",
+      "barcode": "2222222",
+      "itemLevelCallNumber": "1234",
+      "itemLevelCallNumberPrefix": "ca",
+      "itemLevelCallNumberTypeId": "828ae637-dfa3-4265-a1af-5279c436edff",
+      "notes": [],
+      "circulationNotes": [],
+      "itemIdentifier": "9cb57315-deee-48c4-96f0-bc977ae49a3a",
+      "tags": {
+        "tagList": []
+      },
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [
+        "9d8abbe2-1a94-4866-8731-4d12ac09f7a8"
+      ],
+      "purchaseOrderLineIdentifier": null,
+      "materialType": {
+        "id": "dd0bf600-dbd9-44ab-9ff2-e2a61a6539f1",
+        "name": "sound recording"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "permanentLocation": {
+        "id": "d428ca1d-f33b-4d4c-a160-d9f41c657bb7",
+        "name": "A copy of another location"
+      },
+      "metadata": {
+        "createdDate": "2021-10-05T10:23:43.452+00:00",
+        "createdByUserId": "e2f5ebb7-9285-58f8-bc1e-608ac2080861",
+        "updatedDate": "2021-10-06T13:28:29.832+00:00",
+        "updatedByUserId": "e2f5ebb7-9285-58f8-bc1e-608ac2080861"
+      },
+      "effectiveCallNumberComponents": {
+        "callNumber": "1234",
+        "prefix": "ca",
+        "suffix": null,
+        "typeId": "828ae637-dfa3-4265-a1af-5279c436edff"
+      },
+      "effectiveShelvingOrder": "",
+      "isBoundWith": false,
+      "effectiveLocation": {
+        "id": "d428ca1d-f33b-4d4c-a160-d9f41c657bb7",
+        "name": "A copy of another location"
+      }
+    }
+  ],
+  "totalRecords": 1
+}


### PR DESCRIPTION
## Description
Replace the use of `JsonNode` for the responses from mod-inventory (`GET /inventory/items` and `GET /inventory/instances`) with DTOs

## Solution
- Create DTOs for Folio Item/Items Collections and Instance/Instances Collection
- Replace working and manipulation of responses represented as `JsonNode` with DTOs
- add integration test cases

[DCB-2203](https://openlibraryfoundation.atlassian.net/browse/DCB-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[DCB-2203]: https://openlibraryfoundation.atlassian.net/browse/DCB-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ